### PR TITLE
Bump node 20 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,18 @@ jobs:
       matrix:
         include:
           - ruby_version: 3.2
-            node_version: 20.9.0
             node_major: 20
             variant: alpine
             dockerfile: ./alpine/node20/Dockerfile
           - ruby_version: 3.2
-            node_version: 20.9.0
             node_major: 20
             variant: bookworm
             dockerfile: ./bookworm/node20/Dockerfile
           - ruby_version: 3.3
-            node_version: 20.15.0
             node_major: 20
             variant: alpine
             dockerfile: ./alpine/node20/Dockerfile
           - ruby_version: 3.3
-            node_version: 20.15.0
             node_major: 20
             variant: bookworm
             default: true
@@ -82,7 +78,6 @@ jobs:
           build-args: |
             DISTRO=buster
             RUBY_VERSION=${{ matrix.ruby_version }}
-            NODE_VERSION=${{ matrix.node_version }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Currently available combinations:
 
 ## Supported tags
 
-- `latest`, `3.2-18`, `3.2-20`, `3.3-20`
-- `alpine`, `3.2-18-alpine`, `3.2-20-alpine`, `3.3-20-alpine`
+There are `latest` and `alpine` tags available for this image.
+
+For all available tags, see the [Docker Hub repository](https://hub.docker.com/r/koen/ruby-node/tags).
 
 ## Why Node.js and Ruby together?
 
@@ -32,18 +33,18 @@ $ docker run -v "$PWD":/usr/src/app -p "8080:8080" koen/ruby-node
 
 ## Image Variants
 
-The `koen/ruby-node` images come in three flavors, each designed for a
+The `koen/ruby-node` images come in two flavors, both designed for a
 specific use case.
 
 `koen/ruby-node:latest`
 
 This is the defacto image. If you are unsure about what your needs are, you
-probably want to use this one. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.
+probably want to use this one. It is designed to be used both as a throwaway container (mount your source code and start the container to start your app), as well as the base to build other images off of.
 Based on Debian distribution.
 
 `koen/ruby-node:alpine`
 
-This is the smalles image possible. It is based on the Alpine Linux base image.
+This is the smallest image possible. It is based on the Alpine Linux base image.
 
 ## License
 
@@ -78,16 +79,3 @@ issue](https://github.com/koenpunt/docker-ruby-node/issues), especially for
 more ambitious contributions. This gives other contributors a chance to point
 you in the right direction, give you feedback on your design, and help you find
 out if someone else is working on the same thing.
-
-### Collaborators
-
-Individuals making significant and valuable contributions are made Collaborators
-and given commit-access to the project. These individuals are identified by the
-existing Collaborators and their addition as Collaborators is discussed as a
-pull request to this project's README.md.
-
-Note: If you make a significant contribution and are not considered for
-commit-access log an issue or contact one of the Collaborators directly.
-
-- Radovan Šmitala - @radeno
-- Hans Kristian Flaatten - @Starefossen

--- a/alpine/node20/Dockerfile
+++ b/alpine/node20/Dockerfile
@@ -2,7 +2,9 @@ ARG RUBY_VERSION
 
 FROM ruby:${RUBY_VERSION}-alpine
 
-ENV NODE_VERSION 20.15.0
+# Below is verbatim from the respective Dockerfile at https://github.com/nodejs/docker-node
+
+ENV NODE_VERSION 20.19.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -12,7 +14,7 @@ RUN addgroup -g 1000 node \
         curl \
     && ARCH= OPENSSL_ARCH='linux*' && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
-        x86_64) ARCH='x64' CHECKSUM="24a21bc2fd2caf300ea36d716fbfa29ababa8a41bb844e67b6cf8b3d5091792c" OPENSSL_ARCH=linux-x86_64;; \
+        x86_64) ARCH='x64' CHECKSUM="03eabd9b71b3a2376693b521543251edd90dfb188883bcba4c07045d7ee46cd4" OPENSSL_ARCH=linux-x86_64;; \
         x86) OPENSSL_ARCH=linux-elf;; \
         aarch64) OPENSSL_ARCH=linux-aarch64;; \
         arm*) OPENSSL_ARCH=linux-armv4;; \
@@ -43,18 +45,14 @@ RUN addgroup -g 1000 node \
     && export GNUPGHOME="$(mktemp -d)" \
     # gpg keys listed at https://github.com/nodejs/node#release-keys
     && for key in \
-      4ED778F539E3634C779C87C6D7062848A1AB005C \
-      141F07595B7B3FFE74309A937405533BE57C7D57 \
-      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      C0D6248439F1D5604AAFFB4021D900FFDB233756 \
       DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-      61FC681DFB92A079F1685E77973F295594EC4689 \
+      CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
       8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
       890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
       C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
       108F52B48DB57BB0CC439B2997B01419BD92F80A \
       A363A499291CBBC940DD62E41F10027AF002F8B0 \
-      CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
     ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
@@ -81,7 +79,8 @@ RUN addgroup -g 1000 node \
   && apk del .build-deps \
   # smoke tests
   && node --version \
-  && npm --version
+  && npm --version \
+  && rm -rf /tmp/*
 
 ENV YARN_VERSION 1.22.22
 

--- a/bookworm/node20/Dockerfile
+++ b/bookworm/node20/Dockerfile
@@ -2,10 +2,12 @@ ARG RUBY_VERSION
 
 FROM ruby:${RUBY_VERSION}-bookworm
 
+# Below is verbatim from the respective Dockerfile at https://github.com/nodejs/docker-node
+
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.15.0
+ENV NODE_VERSION 20.19.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -22,18 +24,14 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   # gpg keys listed at https://github.com/nodejs/node#release-keys
   && set -ex \
   && for key in \
-    4ED778F539E3634C779C87C6D7062848A1AB005C \
-    141F07595B7B3FFE74309A937405533BE57C7D57 \
-    74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+    C0D6248439F1D5604AAFFB4021D900FFDB233756 \
     DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-    61FC681DFB92A079F1685E77973F295594EC4689 \
+    CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
     C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
     108F52B48DB57BB0CC439B2997B01419BD92F80A \
     A363A499291CBBC940DD62E41F10027AF002F8B0 \
-    CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
   ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
@@ -49,7 +47,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   # smoke tests
   && node --version \
-  && npm --version
+  && npm --version \
+  && rm -rf /tmp/*
 
 ENV YARN_VERSION 1.22.22
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
         - linux/amd64
       args:
         RUBY_VERSION: "3.2"
-        NODE_VERSION: "20.9.0"
 
   rubynode-3.3-20-alpine:
     image: koen/ruby-node:3.3-20-alpine
@@ -17,7 +16,6 @@ services:
         - linux/amd64
       args:
         RUBY_VERSION: "3.3"
-        NODE_VERSION: "20.15.0"
 
   rubynode-3.2-20-bookworm:
     image: koen/ruby-node:3.2-20-bookworm
@@ -27,4 +25,12 @@ services:
         - linux/amd64
       args:
         RUBY_VERSION: "3.2"
-        NODE_VERSION: "20.9.0"
+
+  rubynode-3.3-20-bookworm:
+    image: koen/ruby-node:3.3-20-bookworm
+    build:
+      context: ./bookworm/node20
+      platforms:
+        - linux/amd64
+      args:
+        RUBY_VERSION: "3.3"


### PR DESCRIPTION
This pull request updates the Ruby-Node Docker images and their configurations to align with the latest Node.js version and simplifies the documentation. The key changes include removing explicit Node.js version references from configurations, updating Dockerfiles for Alpine and Bookworm variants, and improving the README for clarity and maintainability.

### Configuration Updates:
* Removed explicit `node_version` from the GitHub Actions workflow matrix and build arguments in `.github/workflows/build.yml`. This simplifies the configuration by relying solely on `node_major` for Node.js versioning. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L15-L30) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L85)
* Removed `NODE_VERSION` from `docker-compose.yml` service definitions, reflecting the same simplification in versioning. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L10) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L20) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L30-R36)

### Dockerfile Updates:
* Updated the Node.js version to `20.19.2` in both `alpine/node20/Dockerfile` and `bookworm/node20/Dockerfile`. This includes updating checksums and GPG keys to match the new version. [[1]](diffhunk://#diff-3ad3d0146c7e0004a1f4b353679b34f7226db1d034d8349aea1d3f79a2c12ce9L5-R7) [[2]](diffhunk://#diff-3ad3d0146c7e0004a1f4b353679b34f7226db1d034d8349aea1d3f79a2c12ce9L15-R17) [[3]](diffhunk://#diff-3ad3d0146c7e0004a1f4b353679b34f7226db1d034d8349aea1d3f79a2c12ce9L46-L57) [[4]](diffhunk://#diff-9fc8bb982e04b0dfdd202b6d4d93abe1e903832249a3c99bc41f6bdaaac48df7R5-R10) [[5]](diffhunk://#diff-9fc8bb982e04b0dfdd202b6d4d93abe1e903832249a3c99bc41f6bdaaac48df7L25-L36)
* Added cleanup steps (`rm -rf /tmp/*`) to reduce image size and remove temporary files after build. [[1]](diffhunk://#diff-3ad3d0146c7e0004a1f4b353679b34f7226db1d034d8349aea1d3f79a2c12ce9L84-R83) [[2]](diffhunk://#diff-9fc8bb982e04b0dfdd202b6d4d93abe1e903832249a3c99bc41f6bdaaac48df7L52-R51)

### Documentation Improvements:
* Simplified the README by replacing the detailed list of tags with a link to the Docker Hub repository for tag reference.
* Corrected a typo in the description of the Alpine variant ("smalles" → "smallest").
* Removed the outdated "Collaborators" section to streamline the README.